### PR TITLE
Specify the origin trials token to use the WebHID API.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,8 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <!-- Origin Trials Token for WebHID API (http://localhost:3000) -->
+    <meta http-equiv="origin-trial" content="AtVj7tyZiBCnbT3+8BJ4LQ6vEiAm4gIoUNDIdCvRFhntI3I3dSfPriO3+ALi/+L9ePE3NLyqDzJ31p46MYaEhg8AAABJeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJmZWF0dXJlIjoiV2ViSElEIiwiZXhwaXJ5IjoxNjExNTczMDM1fQ==">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
# What is this

This pull request provides the origin trials token to use the WebHID API. This token is valid on only the `http://localhost:3000` domain, and the API cannot be used on other all domains.